### PR TITLE
Configuration Access Config.

### DIFF
--- a/CalValEX.cs
+++ b/CalValEX.cs
@@ -50,6 +50,12 @@ namespace CalValEX
             SyncSCalHits
         }
 
+        public static CalValEX instance;
+        public Mod herosmod;
+        public const string heropermission = "CalValEX";
+        public const string heropermissiondisplayname = "Calamity's Vanities";
+        public bool hasPermission;
+
         public static bool Bumble;
         public static bool Wulfrumset;
         public static bool WulfrumsetReal;
@@ -61,6 +67,9 @@ namespace CalValEX
 
         public override void Load()
         {
+            instance = this;
+            herosmod = ModLoader.GetMod("HEROsMod");
+
             DateTime dateTime = DateTime.Now;
             currentDate = dateTime.ToString("dd/MM/yyyy");
             day = dateTime.Day;
@@ -103,6 +112,10 @@ namespace CalValEX
 
         public override void Unload()
         {
+            instance = null;
+            herosmod = null;
+            hasPermission = false;
+
             currentDate = null;
             Bumble = false;
             Wulfrumset = false;
@@ -601,6 +614,30 @@ namespace CalValEX
             recipe.AddTile(ModContent.TileType<StarstruckSynthesizerPlaced>());
             recipe.SetResult(calamityMod.ItemType("MonolithDresser"));
             recipe.AddRecipe();
+        }
+
+        public void SetupHerosMod()
+        {
+            if (herosmod != null)
+            {
+                herosmod.Call(
+                    // Special string
+                    "AddPermission",
+                    // Permission Name
+                    heropermission,
+                    // Permission Display Name
+                    heropermissiondisplayname);
+            }
+        }
+
+        public override void PostAddRecipes()
+        {
+            SetupHerosMod();
+        }
+
+        public bool getPermission()
+        {
+            return hasPermission;
         }
     }
 }


### PR DESCRIPTION
Options for both server owner exclusive config changes or Hero's Mod exclusive config changes via permission system.

Server owner config recommended for Host & Play or for hosting server on the same machine you play on.

Hero's Mod config option is ideal for those that do not fit either of the criteria above or wish to use Hero's Mod permission system. Best for dedicated servers.

Server Side config scope alone allows config to be synced to everyone in multiplayer. It does not prevent players from making changes to config. I had to clarify this to multiple people.

This resolves #7 

_Please pass this on the Calamity Devs. I don't have a direct line of contact with them._