### PR TITLE
Add stream length checking

### DIFF
--- a/CalValEXWorld.cs
+++ b/CalValEXWorld.cs
@@ -156,6 +156,8 @@ namespace CalValEX
         }
         public override void NetReceive(BinaryReader reader)
         {
+            if (reader.BaseStream.Length < 1) 
+                return;
             BitsByte flags = reader.ReadByte();
             BitsByte flags2 = reader.ReadByte();
             rescuedjelly = flags[0];


### PR DESCRIPTION
Unsure of the entire root cause of the problem but this should stabilise this end at least...

```
System.IO.EndOfStreamException: Unable to read beyond the end of the stream.
   at System.IO.BinaryReader.ReadByte()
   at CalValEX.CalValEXWorld.NetReceive(BinaryReader reader) in CalValEXWorld.cs:line 160
   at Terraria.ModLoader.IO.WorldIO.<>c__DisplayClass16_0.<ReceiveModData>b__0(BinaryReader r) in tModLoader\Terraria.ModLoader.IO\WorldIO.cs:line 310
   at Terraria.ModLoader.IO.BinaryIO.SafeRead(BinaryReader reader, Action1 read) in tModLoader\Terraria.ModLoader.IO\BinaryIO.cs:line 58
   at Terraria.ModLoader.IO.WorldIO.ReceiveModData(BinaryReader reader) in tModLoader\Terraria.ModLoader.IO\WorldIO.cs:line 310
   at DMD<Terraria.MessageBuffer::GetData>(MessageBuffer this, Int32 start, Int32 length, Int32& messageType)
   at Trampoline<Terraria.MessageBuffer::GetData>?4128075(MessageBuffer , Int32 , Int32 , Int32& )
   at MagicStorage.Edits.Detours.Vanilla.MessageBuffer_GetData(orig_GetData orig, MessageBuffer self, Int32 start, Int32 length, Int32& messageType) in MagicStorage\Edits\Detours\Vanilla.NetMessage.cs:line 164
   at Hook<Terraria.MessageBuffer::GetData>?31657819(MessageBuffer , Int32 , Int32 , Int32& )
   at Terraria.NetMessage.CheckBytes(Int32 bufferIndex) in tModLoader\Terraria\NetMessage.cs:line 1839
   at Terraria.Netplay.<>c.<InnerClientLoop>b__38_0() in tModLoader\Terraria\Netplay.cs:line 263
   at System.Threading.Tasks.Task.InnerInvoke()
   at System.Threading.Tasks.Task.Execute()
   at System.Threading.Tasks.Task.ExecutionContextCallback(Object obj)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot)
   at System.Threading.Tasks.Task.ExecuteEntry(Boolean bPreventDoubleExecution)
   at System.Threading.Tasks.ThreadPoolTaskScheduler.TryExecuteTaskInline(Task task, Boolean taskWasPreviouslyQueued)
   at System.Threading.Tasks.TaskScheduler.TryRunInline(Task task, Boolean taskWasPreviouslyQueued)
   at System.Threading.Tasks.Task.InternalRunSynchronously(TaskScheduler scheduler, Boolean waitForCompletion)
   at Terraria.Netplay.OnUpdate() in tModLoader\Terraria\Netplay.cs:line 62
   at Terraria.Main.DoUpdate(GameTime gameTime) in tModLoader\Terraria\Main.cs:line 10091
   at Terraria.Main.Update(GameTime gameTime) in tModLoader\Terraria\Main.cs:line 10026
   at Microsoft.Xna.Framework.Game.Tick()
   at Microsoft.Xna.Framework.Game.HostIdle(Object sender, EventArgs e)
   at Microsoft.Xna.Framework.GameHost.OnIdle()
   at Microsoft.Xna.Framework.WindowsGameHost.RunOneFrame()
   at Microsoft.Xna.Framework.WindowsGameHost.ApplicationIdle(Object sender, EventArgs e)
```