### PR TITLE
Fix the bug about PolterChan's MAID mode and some minor modifications to Meldosaurus

### DIFF
--- a/AprilFools/Meldosaurus/MeldWyrmBody.cs
+++ b/AprilFools/Meldosaurus/MeldWyrmBody.cs
@@ -6,7 +6,7 @@ using Terraria.ModLoader;
 
 namespace CalValEX.AprilFools.Meldosaurus
 {
-    public class MeldwyrmBody : ModNPC
+    public class MeldWyrmBody : ModNPC
 	{
 		public override void SetStaticDefaults()
 		{

--- a/AprilFools/Meldosaurus/MeldWyrmHead.cs
+++ b/AprilFools/Meldosaurus/MeldWyrmHead.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace CalValEX.AprilFools.Meldosaurus
 {
-    public class MeldwyrmHead : ModNPC
+    public class MeldWyrmHead : ModNPC
 
 	{
 		public override void SetStaticDefaults()
@@ -50,7 +50,7 @@ namespace CalValEX.AprilFools.Meldosaurus
 			{
 				bestiaryEntry.Info.AddRange(new Terraria.GameContent.Bestiary.IBestiaryInfoElement[] {
 				Terraria.GameContent.Bestiary.BestiaryDatabaseNPCsPopulator.CommonTags.SpawnConditions.Biomes.Surface,
-				new Terraria.GameContent.Bestiary.FlavorTextBestiaryInfoElement($"Mods.CalValEX.Bestiary.MeldwyrmHead")
+				new Terraria.GameContent.Bestiary.FlavorTextBestiaryInfoElement($"Mods.CalValEX.Bestiary.MeldWyrmHead")
 				//("A parasitic tapewyrm that saught refuge inside of the alien dinosaur. It is likely that similar creatures carve out the insides of the mysterious pillars."),
 			});
 			}
@@ -87,9 +87,9 @@ namespace CalValEX.AprilFools.Meldosaurus
 			{
 				int nextSegmentIndex;
 				if (i < 15 - 1)
-					nextSegmentIndex = NPC.NewNPC(NPC.GetSource_FromAI(), (int)NPC.Center.X, (int)NPC.Center.Y, ModContent.NPCType<MeldwyrmBody>(), NPC.whoAmI);
+					nextSegmentIndex = NPC.NewNPC(NPC.GetSource_FromAI(), (int)NPC.Center.X, (int)NPC.Center.Y, ModContent.NPCType<MeldWyrmBody>(), NPC.whoAmI);
 				else 
-					nextSegmentIndex = NPC.NewNPC(NPC.GetSource_FromAI(), (int)NPC.Center.X, (int)NPC.Center.Y, ModContent.NPCType<MeldwyrmTail>(), NPC.whoAmI);
+					nextSegmentIndex = NPC.NewNPC(NPC.GetSource_FromAI(), (int)NPC.Center.X, (int)NPC.Center.Y, ModContent.NPCType<MeldWyrmTail>(), NPC.whoAmI);
 				Main.npc[nextSegmentIndex].realLife = NPC.whoAmI;
 				Main.npc[nextSegmentIndex].ai[2] = NPC.whoAmI;
 				Main.npc[nextSegmentIndex].ai[1] = previousSegment;

--- a/AprilFools/Meldosaurus/MeldWyrmTail.cs
+++ b/AprilFools/Meldosaurus/MeldWyrmTail.cs
@@ -4,7 +4,7 @@ using Terraria.ModLoader;
 
 namespace CalValEX.AprilFools.Meldosaurus
 {
-    public class MeldwyrmTail : ModNPC
+    public class MeldWyrmTail : ModNPC
 
 	{
 		public override void SetStaticDefaults()

--- a/AprilFools/Meldosaurus/Meldosaurus.cs
+++ b/AprilFools/Meldosaurus/Meldosaurus.cs
@@ -412,7 +412,7 @@ namespace CalValEX.AprilFools.Meldosaurus
 			//Clone ram
 			if (NPC.ai[0] == 8)
 			{
-				bool spawnWorms = NPC.CountNPCS(ModContent.NPCType<MeldwyrmHead>()) < 1 && expert;
+				bool spawnWorms = NPC.CountNPCS(ModContent.NPCType<MeldWyrmHead>()) < 1 && expert;
 				if (!Main.expertMode)
                 {
 					NPC.alpha = 80;
@@ -457,8 +457,8 @@ namespace CalValEX.AprilFools.Meldosaurus
 						Terraria.Audio.SoundEngine.PlaySound(SoundID.Zombie5 with { Pitch = SoundID.Zombie5.Pitch - 0.5f }, Main.player[NPC.target].Center);
 						if (Main.netMode != NetmodeID.MultiplayerClient)
 						{
-							NPC.NewNPC(NPC.GetSource_FromAI(), (int)NPC.Center.X, (int)NPC.Center.Y, ModContent.NPCType<MeldwyrmHead>(), 0, NPC.whoAmI, 1);
-							NPC.NewNPC(NPC.GetSource_FromAI(), (int)NPC.Center.X, (int)NPC.Center.Y, ModContent.NPCType<MeldwyrmHead>(), 0, NPC.whoAmI, 2);
+							NPC.NewNPC(NPC.GetSource_FromAI(), (int)NPC.Center.X, (int)NPC.Center.Y, ModContent.NPCType<MeldWyrmHead>(), 0, NPC.whoAmI, 1);
+							NPC.NewNPC(NPC.GetSource_FromAI(), (int)NPC.Center.X, (int)NPC.Center.Y, ModContent.NPCType<MeldWyrmHead>(), 0, NPC.whoAmI, 2);
 						}
 					}
 					NewPhase(1);

--- a/Projectiles/Pets/PolterChan.cs
+++ b/Projectiles/Pets/PolterChan.cs
@@ -1,3 +1,4 @@
+using System;
 using Terraria;
 using Terraria.ModLoader;
 
@@ -29,15 +30,23 @@ namespace CalValEX.Projectiles.Pets
 
         public override void Animation(int state)
         {
-            Mod armasortof;
             Mod infernum;
+            Mod armasortof;
             Mod cplus;
-            ModLoader.TryGetMod("EfficientNohits", out armasortof);
             ModLoader.TryGetMod("InfernumMode", out infernum);
+            ModLoader.TryGetMod("EfficientNohits", out armasortof);
+            bool ida = false;
             ModLoader.TryGetMod("CalValPlus", out cplus);
 
+            if( armasortof != null )
+            {
+                Type playerType = armasortof.Code.GetType("EfficientNohits.EffPlayer");
+                var field = playerType.GetField("InstantDeathAlways");
+                ida = (bool)field.GetValue(null);
+            }
+
             //MAID mode
-            if (CalValEX.CalamityActive && !CalValEXConfig.Instance.Polterskin && ((Main.masterMode && (bool)CalValEX.Calamity.Call("GetDifficultyActive", "death") && (infernum != null && (bool)infernum.Call("GetInfernumActive")) && (armasortof != null && (bool)armasortof.Call("GetModifier", "instantdeathalways"))) || cplus != null))
+            if (CalValEX.CalamityActive && !CalValEXConfig.Instance.Polterskin && ((Main.masterMode && (bool)CalValEX.Calamity.Call("GetDifficultyActive", "death") && (infernum != null && (bool)infernum.Call("GetInfernumActive")) && (armasortof != null && ida )) || cplus != null))
             {
                 if (Projectile.frameCounter++ > 8)
                 {

--- a/Projectiles/Pets/PolterChan.cs
+++ b/Projectiles/Pets/PolterChan.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using Terraria;
 using Terraria.ModLoader;
 
@@ -11,6 +12,18 @@ namespace CalValEX.Projectiles.Pets
         public override float TeleportThreshold => 1440f;
 
         public override Vector2 FlyingOffset => new(68f * -Main.player[Projectile.owner].direction, -50f);
+
+        private static Type _effPlayerType;
+        private static FieldInfo _instantDeathAlwaysField;
+
+        static PolterChan()
+        {
+            if (ModLoader.TryGetMod("EfficientNohits", out Mod armasortof))
+            {
+                _effPlayerType = armasortof.Code.GetType("EfficientNohits.EffPlayer");
+                _instantDeathAlwaysField = _effPlayerType?.GetField("InstantDeathAlways");
+            }
+        }
 
         public override void SetStaticDefaults()
         {
@@ -31,22 +44,18 @@ namespace CalValEX.Projectiles.Pets
         public override void Animation(int state)
         {
             Mod infernum;
-            Mod armasortof;
             Mod cplus;
             ModLoader.TryGetMod("InfernumMode", out infernum);
-            ModLoader.TryGetMod("EfficientNohits", out armasortof);
-            bool ida = false;
             ModLoader.TryGetMod("CalValPlus", out cplus);
 
-            if( armasortof != null )
+            bool ida = false;
+            if (_instantDeathAlwaysField != null)
             {
-                Type playerType = armasortof.Code.GetType("EfficientNohits.EffPlayer");
-                var field = playerType.GetField("InstantDeathAlways");
-                ida = (bool)field.GetValue(null);
+                ida = (bool)_instantDeathAlwaysField.GetValue(null);
             }
 
             //MAID mode
-            if (CalValEX.CalamityActive && !CalValEXConfig.Instance.Polterskin && ((Main.masterMode && (bool)CalValEX.Calamity.Call("GetDifficultyActive", "death") && (infernum != null && (bool)infernum.Call("GetInfernumActive")) && (armasortof != null && ida )) || cplus != null))
+            if (CalValEX.CalamityActive && !CalValEXConfig.Instance.Polterskin && ((Main.masterMode && (bool)CalValEX.Calamity.Call("GetDifficultyActive", "death") && (infernum != null && (bool)infernum.Call("GetInfernumActive")) && ida) || cplus != null))
             {
                 if (Projectile.frameCounter++ > 8)
                 {


### PR DESCRIPTION
I loaded the mods needed by MAID mode. However, when I used the Toy Scythe, only the PolterChan's buff icon appeared.
<img width="1181" height="839" alt="noPolterchan" src="https://github.com/user-attachments/assets/06804172-ec6d-4b57-b638-3954fb91ca14" />
Then I found the following content in the tModLoader log.

[Main Thread/WARN] [tML]:
System.NullReferenceException: Object reference not set to an instance of an object.
   at CalValEX.Projectiles.Pets.PolterChan.Animation(Int32 state) in CalValEX\Projectiles\Pets\PolterChan.cs:line 40
   at CalValEX.Projectiles.Pets.ModFlyingPet.PetBehaviour() in CalValEX\Projectiles\Pets\ModFlyingPet.cs:line 77
   at CalValEX.Projectiles.Pets.ModPet.AI() ......

After testing, I found that it's because the latest version of Nycro's Nohit Efficiency Mod no longer supports the callable GetModifier.
To fix the bug, I added a boolean variable 'ida'(short for InstantDeathAlways). If the 'armasortof' exists, the function obtains the 'EfficientNohits.EffPlayer' type, then gets its 'InstantDeathAlways' field value, and assign the value to the 'ida'. What's more, The armasortof.Call() was replaced by the 'ida'.
Having modified the 'PolterChan.cs', I built the .tmod file with the tModLoader. No error occurs when building. But when I loaded the mods, an error "resource not found" occured. It showed that the tModLoader couldn't find some images about the Meldosaurus.
Then I found the letter "W" is uppercase in these image filenames, "MeldWyrmHead.png""MeldWyrmBody.png""MeldWyrmTail.png", while it is lowercase in code filenames and internal variable names. So I made the following modifications.

MeldwyrmHead.cs -> MeldWyrmHead.cs, MeldwyrmHead.cs -> MeldWyrmBody.cs, MeldwyrmHead.cs -> MeldWyrmTail.cs

The variable names in the Meldosaurus.cs, MeldWyrmHead.cs, MeldWyrmBody.cs, MeldWyrmTail.cs are also modified.
Finally, there was not any error when building, loading and playing. I finally meet the MAID PolterChan!
<img width="1177" height="834" alt="Polterchan" src="https://github.com/user-attachments/assets/4da28447-ae19-4b39-b271-78627a199cbe" />
